### PR TITLE
more descriptive names

### DIFF
--- a/_cases/airplane_airplane_swapped.md
+++ b/_cases/airplane_airplane_swapped.md
@@ -1,5 +1,5 @@
 ---
-name: Swapped Airplane
+name: Swapped Airplane / Airplane
 short_name: airplane_airplane_swapped
 top: Airplane
 top_short_name: airplane

--- a/_cases/moth_moth_swapped.md
+++ b/_cases/moth_moth_swapped.md
@@ -1,5 +1,5 @@
 ---
-name: Swapped Moth
+name: Swapped Moth / Moth
 short_name: moth_moth_swapped
 top: Moth
 top_short_name: moth


### PR DESCRIPTION
Noticed that swapped moth/moth and swapped airplane/airplane were ambiguously called "swapped moth" and "swapped airplane", respectively; minor cleanup to make them consistent